### PR TITLE
ci: Switch to upstream dnscontrol

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,8 +20,8 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: gnome-infra/dnscontrol
-          ref: gandi_v5-auth-changes
+          repository: StackExchange/dnscontrol
+          ref: main
           path: dnscontrol
 
       - uses: actions/setup-go@v5

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,8 +17,8 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: gnome-infra/dnscontrol
-          ref: gandi_v5-auth-changes
+          repository: StackExchange/dnscontrol
+          ref: main
           path: dnscontrol
 
       - uses: actions/setup-go@v5


### PR DESCRIPTION
Gandi v5 changes were merged upstream but there's no stable release yet.