### PR TITLE
Reapply "Drop _acme-challenge for gnome.org"

### DIFF
--- a/domains/gnome.org.js
+++ b/domains/gnome.org.js
@@ -288,7 +288,6 @@ D("gnome.org", REG_GANDI,
 
     // ACME challenges
     CNAME("_acme-challenge.irc", "org.gnome.irc.le.libera.chat."),
-    CNAME("_acme-challenge", "nr30auvvvbz0ecswcu.fastly-validations.com."),
     CNAME("_acme-challenge.api-lb.openshift4", "kaeg7jvowakdptiik2.fastly-validations.com."),
     CNAME("_acme-challenge.pages.gitlab", "8trd9e2zeztt8cfs30.fastly-validations.com."),
     CNAME("_acme-challenge.planeta.es", "ftdf04vnjsgsvm7fsv.fastly-validations.com."),


### PR DESCRIPTION
This reverts commit ac09eb28a25596d088da91d5a668e7bb535a0a8f.